### PR TITLE
Upgrade to Kafka 1.0, improve legacy_name usability

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,5 +152,6 @@ Create the JAR:
 mvn clean package
 ```
 
-Copy the JAR to `/usr/share/java/kafka-serde-tools` on your local Kafka Connect instance to make the 
+Copy the JAR with dependencies (`kafka-connect-protobuf-converter-*-jar-with-dependencies.jar`) to 
+`/usr/share/java/kafka-serde-tools` on your local Kafka Connect instance to make the 
 converter available in Kafka Connect.

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>com.blueapron</groupId>
     <artifactId>kafka-connect-protobuf-converter</artifactId>
     <packaging>jar</packaging>
-    <version>1.3.0</version>
+    <version>2.0.0</version>
 
     <properties>
         <protobuf.version>3.4.0</protobuf.version>
@@ -18,7 +18,7 @@
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>connect-api</artifactId>
-            <version>0.10.2.1</version>
+            <version>1.0.0</version>
         </dependency>
         <dependency>
             <groupId>com.google.protobuf</groupId>
@@ -60,6 +60,24 @@
                     <source>1.8</source>
                     <target>1.8</target>
                 </configuration>
+            </plugin>
+            <plugin>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <version>3.1.0</version>
+                <configuration>
+                    <descriptorRefs>
+                        <descriptorRef>jar-with-dependencies</descriptorRef>
+                    </descriptorRefs>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>make-assembly</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/src/main/java/com/blueapron/connect/protobuf/ProtobufData.java
+++ b/src/main/java/com/blueapron/connect/protobuf/ProtobufData.java
@@ -68,7 +68,7 @@ class ProtobufData {
   private String getConnectFieldName(Descriptors.FieldDescriptor descriptor) {
     String name = descriptor.getName();
     for (Map.Entry<Descriptors.FieldDescriptor, Object> option: descriptor.getOptions().getAllFields().entrySet()) {
-      if (option.getKey().getFullName().equalsIgnoreCase(this.legacyName)) {
+      if (option.getKey().getName().equalsIgnoreCase(this.legacyName)) {
         name = option.getValue().toString();
       }
     }


### PR DESCRIPTION
Upgrade to Kafka 1.0. To make this upgrade, we need to build the jar with its dependencies.

This change also contains a small bugfix to support not using the full path to `legacy_name`