### PR TITLE
Add option to produce a flat Kafka Connect schema with configurable field delimiter.

### DIFF
--- a/src/main/java/com/blueapron/connect/protobuf/ProtobufConverter.java
+++ b/src/main/java/com/blueapron/connect/protobuf/ProtobufConverter.java
@@ -17,7 +17,15 @@ public class ProtobufConverter implements Converter {
   private static final Logger log = LoggerFactory.getLogger(ProtobufConverter.class);
   private static final String PROTO_CLASS_NAME_CONFIG = "protoClassName";
   private static final String LEGACY_NAME_CONFIG = "legacyName";
+
+  private static final String FLAT_CONNECT_SCHEMA_CONFIG = "flatConnectSchema";
+  private static final boolean FLAT_CONNECT_SCHEMA_DEFAULT = false;
+  private static final String FLAT_CONNECT_SCHEMA_FIELD_DELIMITER_CONFIG = "flatConnectSchemaFieldDelimiter";
+  private static final String FLAT_CONNECT_SCHEMA_FIELD_DELIMITER_DEFAULT = "__";
+
   private ProtobufData protobufData;
+  private boolean flatConnectSchema = FLAT_CONNECT_SCHEMA_DEFAULT;
+  private String flatConnectSchemaFieldDelimiter = FLAT_CONNECT_SCHEMA_FIELD_DELIMITER_DEFAULT;
 
   private boolean isInvalidConfiguration(Object proto, boolean isKey) {
     return proto == null && !isKey;
@@ -31,6 +39,16 @@ public class ProtobufConverter implements Converter {
     Object protoClassName = configs.get(PROTO_CLASS_NAME_CONFIG);
     if (isInvalidConfiguration(protoClassName, isKey)) {
       throw new ConnectException("Value converter must have a " + PROTO_CLASS_NAME_CONFIG + " configured");
+    }
+
+    Object flatConnectSchemaConfig = configs.get(FLAT_CONNECT_SCHEMA_CONFIG);
+    if (flatConnectSchemaConfig != null) {
+      flatConnectSchema = Boolean.valueOf(flatConnectSchemaConfig.toString());
+    }
+
+    Object flatFieldDelimiterConfig = configs.get(FLAT_CONNECT_SCHEMA_FIELD_DELIMITER_CONFIG);
+    if (flatFieldDelimiterConfig != null) {
+      flatConnectSchemaFieldDelimiter = flatFieldDelimiterConfig.toString();
     }
 
     if (protoClassName == null) {
@@ -63,6 +81,15 @@ public class ProtobufConverter implements Converter {
       return SchemaAndValue.NULL;
     }
 
-    return protobufData.toConnectData(value);
+    SchemaAndValue connectData = protobufData.toConnectData(value);
+
+    // If plugin has been configured to produce a flat schema and we have a Struct at the top level
+    // (expected for protobufs), we will create a new SchemaAndValue that brings all fields nested
+    // within Structs to the top level.
+    if (flatConnectSchema && connectData.schema().type() == Schema.Type.STRUCT) {
+      connectData = SchemaUtils.flattenNestedStructs(connectData, flatConnectSchemaFieldDelimiter);
+    }
+
+    return connectData;
   }
 }

--- a/src/main/java/com/blueapron/connect/protobuf/SchemaUtils.java
+++ b/src/main/java/com/blueapron/connect/protobuf/SchemaUtils.java
@@ -1,0 +1,48 @@
+package com.blueapron.connect.protobuf;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import org.apache.kafka.connect.data.Field;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaAndValue;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+
+public class SchemaUtils {
+  static SchemaAndValue flattenNestedStructs(SchemaAndValue connectData, String fieldDelimiter) {
+    SchemaBuilder flatSchemaBuilder = SchemaBuilder.struct();
+    Map<String, Object> flatValuesMap = new HashMap<>();
+    String fieldNamePrefix = "";
+    Schema dataSchema = connectData.schema();
+    Struct dataValue = (Struct) connectData.value();
+    populateFlatSchema(flatSchemaBuilder, flatValuesMap, fieldDelimiter, fieldNamePrefix, dataSchema, dataValue);
+
+    Schema flatSchema = flatSchemaBuilder.build();
+    Struct flatStruct = new Struct(flatSchema);
+    for (Entry<String, Object> entry : flatValuesMap.entrySet()) {
+      flatStruct.put(entry.getKey(), entry.getValue());
+    }
+
+    return new SchemaAndValue(flatSchema, flatStruct);
+  }
+
+  private static void populateFlatSchema(SchemaBuilder flatSchemaBuilder, Map<String, Object> flatValuesMap, String fieldDelimiter, String fieldNamePrefix, Schema schema, Struct value) {
+    List<Field> schemaFields = schema.fields();
+    for (Field field : schemaFields) {
+      Schema fieldSchema = field.schema();
+      String fieldName = field.name();
+      Object fieldValue = value.get(fieldName);
+
+      if (fieldSchema.type() == Schema.Type.STRUCT) {
+        String newFieldNamePrefix = fieldNamePrefix + fieldName + fieldDelimiter;
+        populateFlatSchema(flatSchemaBuilder, flatValuesMap, fieldDelimiter, newFieldNamePrefix, fieldSchema, (Struct) fieldValue);
+      } else {
+        String fullFieldName = fieldNamePrefix + fieldName;
+        flatSchemaBuilder.field(fullFieldName, fieldSchema);
+        flatValuesMap.put(fullFieldName, fieldValue);
+      }
+    }
+  }
+}

--- a/src/test/java/com/blueapron/connect/protobuf/ProtobufConverterNestedTest.java
+++ b/src/test/java/com/blueapron/connect/protobuf/ProtobufConverterNestedTest.java
@@ -1,0 +1,82 @@
+package com.blueapron.connect.protobuf;
+
+import static org.junit.Assert.assertEquals;
+
+import com.blueapron.connect.protobuf.NestedTestProtoOuterClass.ComplexType;
+import com.blueapron.connect.protobuf.NestedTestProtoOuterClass.MessageId;
+import com.blueapron.connect.protobuf.NestedTestProtoOuterClass.NestedTestProto;
+import com.blueapron.connect.protobuf.NestedTestProtoOuterClass.Status;
+import com.blueapron.connect.protobuf.NestedTestProtoOuterClass.UserId;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaAndValue;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.junit.Test;
+
+public class ProtobufConverterNestedTest {
+  private final String TEST_NESTED_MESSAGE_CLASS_NAME = "com.blueapron.connect.protobuf.NestedTestProtoOuterClass$NestedTestProto";
+
+  private static final NestedTestProto NESTED_MESSAGE = NestedTestProto.newBuilder()
+    .setUserId(UserId.newBuilder().setAnotherId(MessageId.newBuilder().setId("foo").build()).build())
+    .setIsActive(true)
+    .setComplexType(ComplexType.newBuilder().setOneId("bar").build())
+    .build();
+
+  private Schema getNestedMessageSchema(String fieldDelimiter) {
+    final SchemaBuilder builder = SchemaBuilder.struct();
+    builder.field("user_id" + fieldDelimiter + "ba_com_user_id", SchemaBuilder.string().optional().build());
+    builder.field("user_id" + fieldDelimiter + "other_user_id", SchemaBuilder.int32().optional().build());
+    builder.field("user_id" + fieldDelimiter + "another_id" + fieldDelimiter + "id", SchemaBuilder.string().optional().build());
+    builder.field("is_active", SchemaBuilder.bool().optional().build());
+    builder.field("experiments_active", SchemaBuilder.array(SchemaBuilder.string().optional().build()).optional().build());
+    builder.field("updated_at", org.apache.kafka.connect.data.Timestamp.builder().optional().build());
+    builder.field("status", SchemaBuilder.string().optional().build());
+    builder.field("complex_type" + fieldDelimiter + "one_id", SchemaBuilder.string().optional().build());
+    builder.field("complex_type" + fieldDelimiter + "other_id", SchemaBuilder.int32().optional().build());
+    builder.field("complex_type" + fieldDelimiter + "is_active", SchemaBuilder.bool().optional().build());
+    builder.field("map_type", SchemaBuilder.array(SchemaBuilder.struct().field("key", Schema.OPTIONAL_STRING_SCHEMA).field("value", Schema.OPTIONAL_STRING_SCHEMA).optional().build()).optional().build());
+    return builder.build();
+  }
+
+  private Struct getNestedMessageValue(String fieldDelimiter) {
+    Schema schema = getNestedMessageSchema(fieldDelimiter);
+    Struct result = new Struct(schema.schema());
+    result.put("user_id" + fieldDelimiter + "another_id" + fieldDelimiter + "id", "foo");
+    result.put("is_active", true);
+    result.put("experiments_active", Collections.emptyList());
+    result.put("updated_at", new Date(0));
+    result.put("status", Status.ACTIVE.name());
+    result.put("complex_type" + fieldDelimiter + "one_id", "bar");
+    result.put("complex_type" + fieldDelimiter + "is_active", false);
+    result.put("map_type", Collections.emptyList());
+    return result;
+  }
+
+  private ProtobufConverter getConfiguredProtobufConverter(String protobufClassName, boolean flatConnectSchema, String flatConnectSchemaFieldDelimiter, boolean isKey) {
+    ProtobufConverter protobufConverter = new ProtobufConverter();
+
+    Map<String, Object> configs = new HashMap<String, Object>();
+    configs.put("protoClassName", protobufClassName);
+    configs.put("flatConnectSchema", flatConnectSchema);
+    configs.put("flatConnectSchemaFieldDelimiter", flatConnectSchemaFieldDelimiter);
+
+    protobufConverter.configure(configs, isKey);
+
+    return protobufConverter;
+  }
+
+  @Test
+  public void testToConnectDataForNestedValue() {
+    final String fieldDelimiter = "$";
+
+    ProtobufConverter testMessageConverter = getConfiguredProtobufConverter(TEST_NESTED_MESSAGE_CLASS_NAME, true, fieldDelimiter, false);
+    SchemaAndValue result = testMessageConverter.toConnectData("my-topic", NESTED_MESSAGE.toByteArray());
+    SchemaAndValue expected = new SchemaAndValue(getNestedMessageSchema(fieldDelimiter), getNestedMessageValue(fieldDelimiter));
+
+    assertEquals(expected, result);
+  }
+}


### PR DESCRIPTION
The `Flatten` transform is not able to handle deletes, so we're going back to adding configuration to the protobuf converter in order to satisfy the DSE Connector.