### PR TITLE
Add Schema name while converting to connect schema.

### DIFF
--- a/src/main/java/com/blueapron/connect/protobuf/ProtobufData.java
+++ b/src/main/java/com/blueapron/connect/protobuf/ProtobufData.java
@@ -189,7 +189,7 @@ class ProtobufData {
           break;
         }
 
-        builder = SchemaBuilder.struct();
+        builder = SchemaBuilder.struct().name(descriptor.getJsonName());
         for (Descriptors.FieldDescriptor fieldDescriptor : descriptor.getMessageType().getFields()) {
           builder.field(getConnectFieldName(fieldDescriptor), toConnectSchema(fieldDescriptor));
         }


### PR DESCRIPTION
Hi,

We are implementing a Kafka Source Connector, in which we are using kafka-connect-protobuf-converter to convert protobuf to connect Schema (in order to generate the SourceRecord). We are seeing an error "org.apache.avro.SchemaParseException: Can't redefine: io.confluent.connect.avro.ConnectDefault" when this connect schema is converted to avro via schema-registry. The error seems to be because of the missing name for Struct Schema. If a Schema name is not provided then a default name is considered. And if there is an embedded Struct schema, then it will try to use the same default name to both and fails to redefine.
I have added a fix to this PR, that will set the Schema name for (Type: Struct) that will further fix this error.