### PR TITLE
Propagate null timestamps and dates [updated with CI fix]

### DIFF
--- a/src/main/java/com/blueapron/connect/protobuf/ProtobufData.java
+++ b/src/main/java/com/blueapron/connect/protobuf/ProtobufData.java
@@ -231,11 +231,17 @@ class ProtobufData {
     try {
       if (isProtobufTimestamp(schema)) {
         com.google.protobuf.Timestamp timestamp = (com.google.protobuf.Timestamp) value;
+        if (timestamp == timestamp.getDefaultInstanceForType()) {
+          return null;
+        }
         return Timestamp.toLogical(schema, Timestamps.toMillis(timestamp));
       }
 
       if (isProtobufDate(schema)) {
         com.google.type.Date date = (com.google.type.Date) value;
+        if (date == date.getDefaultInstanceForType()) {
+          return null;
+        }
         return ProtobufUtils.convertFromGoogleDate(date);
       }
 

--- a/src/main/java/com/blueapron/connect/protobuf/ProtobufData.java
+++ b/src/main/java/com/blueapron/connect/protobuf/ProtobufData.java
@@ -3,6 +3,7 @@ package com.blueapron.connect.protobuf;
 
 import com.google.protobuf.ByteString;
 import com.google.protobuf.Descriptors;
+import com.google.protobuf.Descriptors.FieldDescriptor;
 import com.google.protobuf.Descriptors.OneofDescriptor;
 import com.google.protobuf.GeneratedMessageV3;
 import com.google.protobuf.InvalidProtocolBufferException;
@@ -34,7 +35,6 @@ import static com.google.protobuf.Descriptors.FieldDescriptor.Type.ENUM;
 import static com.google.protobuf.Descriptors.FieldDescriptor.Type.FLOAT;
 import static com.google.protobuf.Descriptors.FieldDescriptor.Type.INT32;
 import static com.google.protobuf.Descriptors.FieldDescriptor.Type.INT64;
-import static com.google.protobuf.Descriptors.FieldDescriptor.Type.MESSAGE;
 import static com.google.protobuf.Descriptors.FieldDescriptor.Type.SINT32;
 import static com.google.protobuf.Descriptors.FieldDescriptor.Type.SINT64;
 import static com.google.protobuf.Descriptors.FieldDescriptor.Type.STRING;
@@ -224,7 +224,7 @@ class ProtobufData {
     final String fieldName = getConnectFieldName(fieldDescriptor);
     final Field field = schema.field(fieldName);
     Object obj = null;
-    if (fieldDescriptor.getType() != MESSAGE || fieldDescriptor.isRepeated() || fieldDescriptor.isMapField() || message.hasField(fieldDescriptor)) {
+    if (fieldDescriptor.getType() != FieldDescriptor.Type.MESSAGE || fieldDescriptor.isRepeated() || fieldDescriptor.isMapField() || message.hasField(fieldDescriptor)) {
       obj = toConnectData(field.schema(), message.getField(fieldDescriptor));
     }
     result.put(fieldName, obj);

--- a/src/test/java/com/blueapron/connect/protobuf/ProtobufDataTest.java
+++ b/src/test/java/com/blueapron/connect/protobuf/ProtobufDataTest.java
@@ -26,6 +26,7 @@ import org.junit.Test;
 import java.nio.ByteBuffer;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -396,6 +397,35 @@ public class ProtobufDataTest {
     String expectedName = "TimestampValue";
 
     Timestamp timestamp = Timestamps.fromMillis(expectedValue.getTime());
+    TimestampValueOuterClass.TimestampValue.Builder builder = TimestampValueOuterClass.TimestampValue.newBuilder();
+    builder.setValue(timestamp);
+    TimestampValueOuterClass.TimestampValue message = builder.build();
+
+    ProtobufData protobufData = new ProtobufData(TimestampValueOuterClass.TimestampValue.class, LEGACY_NAME);
+    SchemaAndValue result = protobufData.toConnectData(message.toByteArray());
+
+    Schema timestampSchema = org.apache.kafka.connect.data.Timestamp.builder().optional().build();
+    assertEquals(getExpectedSchemaAndValue(timestampSchema, expectedValue, expectedName), result);
+  }
+
+  @Test
+  public void testToConnectNullTimestamp() {
+    String expectedName = "TimestampValue";
+    TimestampValueOuterClass.TimestampValue message = TimestampValueOuterClass.TimestampValue.getDefaultInstance();
+
+    ProtobufData protobufData = new ProtobufData(TimestampValueOuterClass.TimestampValue.class, LEGACY_NAME);
+    SchemaAndValue result = protobufData.toConnectData(message.toByteArray());
+
+    Schema timestampSchema = org.apache.kafka.connect.data.Timestamp.builder().optional().build();
+    assertEquals(getExpectedSchemaAndValue(timestampSchema, null, expectedName), result);
+  }
+
+  @Test
+  public void testToConnectEpochTimestamp() {
+    java.util.Date expectedValue = java.util.Date.from(Instant.EPOCH);
+    String expectedName = "TimestampValue";
+
+    Timestamp timestamp = Timestamp.getDefaultInstance();
     TimestampValueOuterClass.TimestampValue.Builder builder = TimestampValueOuterClass.TimestampValue.newBuilder();
     builder.setValue(timestamp);
     TimestampValueOuterClass.TimestampValue message = builder.build();


### PR DESCRIPTION
Fixes #31. This is just one import change to @matthewrj's [fix branch](https://github.com/matthewrj/kafka-connect-protobuf-converter/tree/fix/null-timestamps) so the CI passes. This replaces #32.