### PR TITLE
handle null values from connect data

### DIFF
--- a/src/main/java/com/blueapron/connect/protobuf/ProtobufData.java
+++ b/src/main/java/com/blueapron/connect/protobuf/ProtobufData.java
@@ -422,6 +422,10 @@ class ProtobufData {
   }
 
   private void fromConnectData(com.google.protobuf.GeneratedMessageV3.Builder builder, Field field, Object value) {
+    if (value == null) {
+      return; // Ignore missing values
+    }
+
     final String protobufFieldName = getProtoFieldName(builder.getDescriptorForType().getFullName(), field.name());
     final Descriptors.FieldDescriptor fieldDescriptor = builder.getDescriptorForType().findFieldByName(protobufFieldName);
     if (fieldDescriptor == null) {

--- a/src/test/java/com/blueapron/connect/protobuf/ProtobufDataTest.java
+++ b/src/test/java/com/blueapron/connect/protobuf/ProtobufDataTest.java
@@ -761,6 +761,17 @@ public class ProtobufDataTest {
   }
 
   @Test
+  public void testFromConnectNullTimestampOptionalField() throws ParseException, InvalidProtocolBufferException {
+    Schema timestampSchema = org.apache.kafka.connect.data.Timestamp.builder().optional().build();
+
+    Struct struct = wrapValueStruct(timestampSchema.schema(), null);
+
+    ProtobufData protobufData = new ProtobufData(TimestampValueOuterClass.TimestampValue.class, "legacy-name");
+    Message message = TimestampValueOuterClass.TimestampValue.parseFrom(protobufData.fromConnectData(struct));
+    assertEquals(0, message.getAllFields().size());
+  }
+
+  @Test
   public void testFromConnectDate() throws ParseException, InvalidProtocolBufferException {
     Schema dateSchema = org.apache.kafka.connect.data.Date.builder().optional().build();
 
@@ -895,6 +906,7 @@ public class ProtobufDataTest {
     java.util.Date value = sdf.parse("2017/09/18");
 
     Struct struct = new Struct(getExpectedNestedTestProtoSchema());
+    struct.put("user_id", NestedTestProtoOuterClass.UserId.newBuilder().setBaComUserId("ba_com_user_id"));
     struct.put("updated_at", value);
 
     ProtobufData protobufData = new ProtobufData(NestedTestProto.class, LEGACY_NAME);


### PR DESCRIPTION
Ignore setting fields whose values are null. Blueapron's kafka-connect-protobuf-converter fails with NullPointerException if the int64 (logical Timestamp type) field's value is null.

```
org.apache.kafka.connect.errors.ConnectException: Tolerance exceeded in error handler
        at org.apache.kafka.connect.runtime.errors.RetryWithToleranceOperator.execAndHandleError(RetryWithToleranceOperator.java:178)
        at org.apache.kafka.connect.runtime.errors.RetryWithToleranceOperator.execute(RetryWithToleranceOperator.java:104)
        at org.apache.kafka.connect.runtime.WorkerSourceTask.convertTransformedRecord(WorkerSourceTask.java:284)
        at org.apache.kafka.connect.runtime.WorkerSourceTask.sendRecords(WorkerSourceTask.java:309)
        at org.apache.kafka.connect.runtime.WorkerSourceTask.execute(WorkerSourceTask.java:234)
        at org.apache.kafka.connect.runtime.WorkerTask.doRun(WorkerTask.java:177)
        at org.apache.kafka.connect.runtime.WorkerTask.run(WorkerTask.java:227)
        at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
        at java.util.concurrent.FutureTask.run(FutureTask.java:266)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
        at java.lang.Thread.run(Thread.java:748)
Caused by: java.lang.NullPointerException
        at org.apache.kafka.connect.data.Timestamp.fromLogical(Timestamp.java:51)
        at com.blueapron.connect.protobuf.ProtobufData.fromConnectData(ProtobufData.java:452)
        at com.blueapron.connect.protobuf.ProtobufData.fromConnectData(ProtobufData.java:418)
        at com.blueapron.connect.protobuf.ProtobufConverter.fromConnectData(ProtobufConverter.java:60)
        at org.apache.kafka.connect.runtime.WorkerSourceTask.lambda$convertTransformedRecord$2(WorkerSourceTask.java:284)
        at org.apache.kafka.connect.runtime.errors.RetryWithToleranceOperator.execAndRetry(RetryWithToleranceOperator.java:128)
        at org.apache.kafka.connect.runtime.errors.RetryWithToleranceOperator.execAndHandleError(RetryWithToleranceOperator.java:162)
        ... 11 more
```