### PR TITLE
Update proto version to latest

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>com.blueapron</groupId>
     <artifactId>kafka-connect-protobuf-converter</artifactId>
     <packaging>jar</packaging>
-    <version>3.1.1-SNAPSHOT</version>
+    <version>3.2.0-SNAPSHOT</version>
 
     <name>com.blueapron:kafka-connect-protobuf-converter</name>
     <description>Converter plugin for Kafka Connect. A converter controls the format of the data
@@ -19,7 +19,7 @@
 
     <properties>
         <java.version>1.8</java.version>
-        <protobuf.version>3.11.1</protobuf.version>
+        <protobuf.version>3.20.0</protobuf.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 


### PR DESCRIPTION
This is a bit of a longshot, since I can't explain *why* this would fix a bug. But maybe it's worth updating our version of the Java protobuf code used by this connector to a newer version.

[no-jira] Possible fix for issues in Kafka Connect